### PR TITLE
ci: defina workflow para aplicar versão gerada em arquivos

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,35 @@
+name: prepare-release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update-version-in-pr:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - run: |
+          CHANGED=$(git diff origin/main...HEAD .release-please-manifest.json \
+          | grep -oE '^+' \
+          | grep -oE '"[^"]+": "[^"]+"' \
+          | sed 's/[",]//g')
+          echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+        id: changes
+
+      - if: ${{ contains(steps.changes.outputs.changed, 'src/joomla') }}
+        id: bump
+        run: |
+          VERSION=$(echo ${{ steps.changes.outputs.changed }} | sed -rn 's/src\/joomla:\s(.*)$/\1/p')
+          php ./src/joomla/build/bump.php -v $VERSION
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore: version bump ${{ steps.bump.outputs.version }}"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,19 +19,3 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ steps.release.outputs['src/joomla--release_created'] == 'true' }}
-        run: |
-          php ./src/joomla/build/bump.php -v ${{ steps.release.outputs['src/joomla--version'] }}
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git commit -a -m 'chore: bump files [skip ci]'
-          git push origin ${{ github.head_ref }}
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
O release-please é limitado no sentido de não permitir execução de scripts personalizados que estendam a aplicação do versionamento e/ou valores customizados em múltiplos arquivos