### PR TITLE
ci: remova referência a branch main

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -2,8 +2,6 @@ name: prepare-release
 
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, reopened, synchronize]
 
 jobs:


### PR DESCRIPTION
A action prepare-release não foi acionada quando o PR de release foi aberto. Esta é uma tentativa para que o gatilho seja acionado.