### PR TITLE
fix: corrija a expressão regular para substituir a versão

### DIFF
--- a/src/joomla/README.md
+++ b/src/joomla/README.md
@@ -1,0 +1,39 @@
+# test
+
+> Descrição Test v0.0
+> Test_v0.0
+
+## Tecnologias Utilizadas
+
+## Funcionalidades
+
+- [ ]
+
+## Autor
+
+[Rene Bentes Pinto](https://github.com/renebentes)
+
+## Contribuindo
+
+Contribuições são bem-vindas!
+
+Se você achar algum problema ou tiver sugestões para melhorias, por favor, abra uma [_Issue_][issues] ou envie uma [_Pull Request (PR)_][pulls] para nosso [repositório][repo].
+
+Você também pode verificar as _Issues_ e _Pull Requests_ existentes com os quais poderia ajudar.
+
+Ao contribuir com este projeto, por favor, siga o estilo de codificação existente, use [conventional commits][commits] em suas mensagens de commit e submeta suas alterações em uma branch separada.
+
+## Notas de Lançamento
+
+Você pode [ver as notas de lançamento aqui.](CHANGELOG.md)
+
+## Licença
+
+Copyright (c) 2026 Rene Bentes Pinto
+
+Este projeto está sob a licença **GNU GPLv2**. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
+
+[repo]: https://github.com/renebentes/release-please
+[issues]: https://github.com/renebentes/release-please/issues
+[pulls]: https://github.com/renebentes/release-please/pulls
+[commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/src/joomla/build/bump.php
+++ b/src/joomla/build/bump.php
@@ -201,8 +201,8 @@ foreach ($packageJsonFiles as $packageJsonFile) {
 foreach ($readMeFiles as $readMeFile) {
     if (file_exists($rootPath . $readMeFile)) {
         $fileContents = file_get_contents($rootPath . $readMeFile);
-        $fileContents = preg_replace('#Test v[0-9]+\.[0-9]', 'Test v' . $version['main'], $fileContents);
-        $fileContents = preg_replace('#Test_v[0-9]+\.[0-9]', 'Test_v' . $version['main'], $fileContents);
+        $fileContents = preg_replace('#Test v[0-9]+\.[0-9]#', 'Test v' . $version['main'], $fileContents);
+        $fileContents = preg_replace('#Test_v[0-9]+\.[0-9]#', 'Test_v' . $version['main'], $fileContents);
         file_put_contents($rootPath . $readMeFile, $fileContents);
     }
 }


### PR DESCRIPTION
Estava ausente o caractere de fechamento na expressão regular responsável por atualizar a versão em arquivos README. Com isso, todo o conteúdo do arquivo era excluído.