### PR TITLE
fix: corrija pacote de referência

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -3,7 +3,9 @@
   "release-type": "php",
   "separate-pull-requests": true,
   "packages": {
-    ".": {}
+    "src/joomla": {
+      "component": "Joomla"
+    }
   },
   "extra-files": [
     { "type": "json", "path": "package.json", "jsonpath": "$.version" }

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,9 +14,9 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: ".github/release-please/config.json"
           manifest-file: ".github/release-please/manifest.json"
-          token: ${{ secrets.PAT_RELEASE_PLEASE }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Todo o conteúdo necessário para o release do tipo PHP está fora da raiz do repositório. Nesse caso, optou-se por readicionar o pacote como um componente para que tudo seja encontrado normalmente.

