### PR TITLE
chore: use novamente o PAT criado anteriormente

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,4 +19,4 @@ jobs:
         with:
           config-file: ".github/release-please/config.json"
           manifest-file: ".github/release-please/manifest.json"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_RELEASE_PLEASE }}


### PR DESCRIPTION
Ao que tudo indica, usar o GITHUB_TOKEN aqui pode estar influenciando na chamada de fluxo adicional - há um loop?