### PR TITLE
ci: restrinja a execução do fluxo

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -3,6 +3,8 @@ name: prepare-release
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    branches:
+      - main
 
 jobs:
   update-version-in-pr:
@@ -17,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          token: ${{ secrets.PAT_RELEASE_PLEASE }}
 
       - name: Determine release version
         run: |


### PR DESCRIPTION
Foi adicionado o uso do token PAT_RELEASE_PLEASE para manter o fluxo no mesmo contexto da criação da release